### PR TITLE
Implements template caching

### DIFF
--- a/lib/jekyll/template.rb
+++ b/lib/jekyll/template.rb
@@ -19,7 +19,6 @@ module Jekyll
       def initialize(tag_name, markup, tokens)
         super
         @root_path = false
-        @template_content = false
 
         # @template_name = markup
         if markup =~ Syntax
@@ -53,6 +52,8 @@ module Jekyll
       # - supports custom attributes to be used in template
       def render(context)
         content = super
+        # Set the root_path
+        @root_path = context.registers[:site].source
         # Remove leading whitespace
         # content = content.lstrip
         compressor = HtmlCompressor::Compressor.new({
@@ -63,7 +64,13 @@ module Jekyll
           :remove_comments => true
         })
         site = context.registers[:site]
-        template = load_template(context)
+
+        add_template_to_dependency(site, @template_name, context)
+        template_obj = load_cached_template(@template_name, context)
+        template_data = template_obj["data"]
+        update_attributes(template_data)
+
+        template = template_obj["template"]
 
         # Define the default template attributes
         # Source:
@@ -73,20 +80,18 @@ module Jekyll
         context["template"] = Hash.new
 
         # Parse and extend template's front-matter with content front-matter
-        content = parse_front_matter(content)
+        content_data = get_front_matter(content)
+        update_attributes(content_data)
+        
+        # Remove front matter
+        content = strip_front_matter(content)
 
         # Setting template attributes from @attributes
         # This allows for @attributes to be used within the template as
         # {{ template.atttribute_name }}
         if @attributes
           @attributes.each do |key, value|
-            # Render the attribute(s) with context
-            if value.instance_of? Liquid::VariableLookup
-              # val = value.name
-              val = context.evaluate(value)
-            else
-              val = context.evaluate(value)
-            end
+            val = context.evaluate(value)
             context["template"][key] = val
 
             # Adjust sanitize if parse: html
@@ -103,18 +108,13 @@ module Jekyll
         unless @sanitize
           converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
           content = content.to_s.unindent
-          @content = converter.convert(content)
+          content = converter.convert(content)
         else
-          @content = content.to_s.unindent
-        end
-
-        # handling empty content
-        if @content.empty?
-          @content = "<!-- Template: #{ @template_name } -->"
+          content = content.to_s.unindent
         end
 
         # setting the template content
-        context["template"]["content"] = @content
+        context["template"]["content"] = content
 
         # rendering the template with the content
         @output = template.render( context )
@@ -122,20 +122,61 @@ module Jekyll
         @output = compressor.compress(@output)
       end
 
+      def update_attributes(data)
+        if data
+          @attributes = @attributes.merge(data)
+        end
+      end
+
+      # add_template_to_dependency(site, path, context)
+      # source: https://github.com/jekyll/jekyll/blob/e509cf2139d1a7ee11090b09721344608ecf48f6/lib/jekyll/tags/include.rb
+      def add_template_to_dependency(site, path, context)
+        if context.registers[:page] && context.registers[:page].key?("path")
+          site.regenerator.add_dependency(
+            site.in_source_dir(context.registers[:page]["path"]),
+            path
+          )
+        end
+      end
+
+      # load_cached_template(path, context)
+      # source: https://github.com/jekyll/jekyll/blob/e509cf2139d1a7ee11090b09721344608ecf48f6/lib/jekyll/tags/include.rb
+      def load_cached_template(path, context)
+        context.registers[:cached_templates] ||= {}
+        cached_templates = context.registers[:cached_templates]
+
+        if cached_templates.key?(path)
+          cached_templates[path]
+        else
+          begin
+            template = load_template(context)
+            cached_templates[path] = template
+          end
+        end
+      end
+
+      # get_template_path(path)
+      # Returns: A full file path of the template
+      # @param    path    { string }
+      def get_template_path(path)
+        # default template path
+        dir = @root_path.to_s
+        view = "_templates/" + path.to_s
+        File.join(dir, view).to_s
+      end
+
       # get_template_content(template)
       # Description: Opens, reads, and returns template content as string.
       # Returns: Template content
       # @param    template    { string }
       def get_template_content(template)
-        # default template path
-        view = "_templates/" + template
-        file_path = File.join(@root_path, view)
+        file_path = get_template_path(template)
         path = File.read(file_path.strip)
         # returns template content
         path
       end
 
-      # load_template(template)
+      # load_template(context)
       # Description: Extends Liquid's default load_template method. Also provides
       # extra enhancements:
       # - parses and sets template front-matter content
@@ -143,15 +184,23 @@ module Jekyll
       def load_template(context)
         # Set the root_path
         @root_path = context.registers[:site].source
+        file_path = get_template_path(@template_name)
+        file = context.registers[:site]
+          .liquid_renderer
+          .file(file_path)
         # Set the template_content
-        @template_content = get_template_content(@template_name)
-        # Parse front matter
-        @template_content = parse_front_matter(@template_content)
+        template_content = get_template_content(@template_name)
 
-        if @template_content
-          Liquid::Template.parse(@template_content)
+        template_obj = Hash.new
+        data = get_front_matter(template_content)
+        content = strip_front_matter(template_content)
+
+        if template_content
+          template_obj["data"] = data 
+          template_obj["template"] = file.parse(content)
+          template_obj
         else
-          raise Liquid::SyntaxError, "Could not find #{view} in your templates"
+          raise Liquid::SyntaxError, "Could not find #{file_path} in your templates"
         end
       end
 
@@ -173,22 +222,36 @@ module Jekyll
         content
       end
 
-      # parse_front_matter(content)
-      # Description: Parses and sets YAML front-matter content.
-      # Returns: Template content, with front-matter removed.
+      # get_front_matter(content)
+      # Returns: A hash of data parsed from the content's YAML
       # @param    content    { string }
-      def parse_front_matter(content)
+      def get_front_matter(content)
         # Strip leading white-spaces
         content = unindent(content)
-
+        data = Hash.new
         if content =~ YAML_FRONT_MATTER_REGEXP
           front_matter = Regexp.last_match(0)
           # Push YAML data to the template's attributes
           values = SafeYAML.load(front_matter)
           # Set YAML data to @attributes
           values.each do |key, value|
-            @attributes[key] = value
+            data[key] = value
           end
+          # Returns data
+          data
+        end
+      end
+
+      # strip_front_matter(content)
+      # Description: Removes the YAML front-matter content.
+      # Returns: Template content, with front-matter removed.
+      # @param    content    { string }
+      def strip_front_matter(content)
+        # Strip leading white-spaces
+        content = unindent(content)
+
+        if content =~ YAML_FRONT_MATTER_REGEXP
+          front_matter = Regexp.last_match(0)
           # Returns content with stripped front-matter
           content = content.gsub(front_matter, "")
         end

--- a/test/test_only.rb
+++ b/test/test_only.rb
@@ -1,0 +1,20 @@
+
+require 'helper'
+
+class TestTemplate < JekyllUnitTest
+  context "jekyll-template" do
+    setup do
+      @site = Site.new(site_configuration)
+      @site.read
+      @site.generate
+      @site.render
+    end
+
+    should "render templates with list in YAML" do
+      post = @site.posts.docs[0]
+      assert_equal(true, true)
+    end
+
+
+  end
+end


### PR DESCRIPTION
Borrowing concepts from Jekyll's include.rb, this update implements basic template caching. "Dumb" pre-rendered markup is cached by adding it as Jekyll site dependency, which is outputted as a Hash in .jekyll-metadata. This data is referred to when files are regenerated.

Resolves https://github.com/helpscout/jekyll-template/issues/1