### PR TITLE
Fixes data scoping for nested templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 /.bundle/
 /.yardoc
 /Gemfile.lock

--- a/lib/jekyll/template.rb
+++ b/lib/jekyll/template.rb
@@ -1,7 +1,6 @@
 require "htmlcompressor"
 require "jekyll"
 require "jekyll/template/version"
-require "SecureRandom"
 
 module Jekyll
   module Tags
@@ -25,7 +24,7 @@ module Jekyll
           @template_name = $1.freeze
           @attributes = {}
           @sanitize = false
-          @id = SecureRandom.uuid
+          @id = rand(36**8).to_s(36)
 
           # Parse parameters
           # Source: https://gist.github.com/jgatjens/8925165

--- a/test/source/_templates/data.html
+++ b/test/source/_templates/data.html
@@ -1,0 +1,7 @@
+---
+title: "Default title"
+---
+
+{{ template.content }}
+
+<h1>{{ template.title }}</h1>

--- a/test/source/_templates/yaml-nest.html
+++ b/test/source/_templates/yaml-nest.html
@@ -1,19 +1,24 @@
 ---
 title: "Hello"
-heading: "There"
+should-be: "Hello"
 ---
 
-<h1>{{ template.title }}</h1>
-
-{% template milk.html %}
+{% template data.html %}
 ---
-title: {{ template.heading }}
+title: "Level 1"
 ---
-
-  {% template milk.html %}
-  ---
-  title: {{ template.heading }}
-  ---
+  {% template data.html %}
+    {% template data.html %}
+    ---
+    title: "Level 3"
+    ---
+    {% endtemplate %}
   {% endtemplate %}
 {% endtemplate %}
+{% template data.html %}
+---
+title: "Level 1 Dupe"
+---
+{% endtemplate %}
 
+<h1>{{ template.title }}</h1>

--- a/test/test_template_yaml.rb
+++ b/test/test_template_yaml.rb
@@ -9,24 +9,26 @@ class TestTemplate < JekyllUnitTest
       @site.render
     end
 
-    # should "render nested templates with same YAML keys" do
-    #   post = @site.posts.docs[18]
-    #   expected = <<EXPECTED
-# <h1>One</h1>
-# <div class=\"milk\"> <p>Content</p> <h1>Two</h1> <div class=\"milk\"> <h1>Three</h1> <div class=\"milk\"> </div> </div> <h1>Also two</h1> <div class=\"milk\"> </div> </div>
-# EXPECTED
-    #   assert_equal(expected, post.output)
-    # end
-
-    should "render nested templates inherit data from parent templates" do
-      post = @site.posts.docs[20]
+    should "render nested templates with same YAML keys" do
+      post = @site.posts.docs[18]
       expected = <<EXPECTED
-<h1>Hello</h1>
-<h1>There</h1>
-<div class="milk"> <h1>There</h1> <div class="milk"> </div> </div>
+<h1>One</h1>
+<div class=\"milk\"> <p>Content</p> <h1>Two</h1> <div class=\"milk\"> <h1>Three</h1> <div class=\"milk\"> </div> </div> <h1>Also two</h1> <div class=\"milk\"> </div> </div>
 EXPECTED
       assert_equal(expected, post.output)
-      # assert_equal(true, true)
     end
+
+    should "WUT" do
+      post = @site.posts.docs[20]
+      expected = <<EXPECTED
+<h1>Level 3</h1>
+<h1>Default title</h1>
+<h1>Level 1</h1>
+<h1>Level 1 Dupe</h1>
+<h1>Hello</h1>
+EXPECTED
+      assert_equal(expected, post.output)
+    end
+
   end
 end


### PR DESCRIPTION
Resolves https://github.com/helpscout/jekyll-template/issues/3

Allows for scoped data to work as expected:

Example:
```
---
title: Hello
---
{% template other.html %}
---
title: There
---
{% endtemplate %}
{{ template.title }}
```

Should render:
```
<p> There </p>
<p> Hello </p>
```

Whereas before, it would render:
```
<p> There </p>
<p> There </p>
```

The problem was that the child template's data overwrote the parent's template data, which caused the data leak.
