### PR TITLE
Fixes data scoping for multiple same-level nests

### DIFF
--- a/lib/jekyll/template.rb
+++ b/lib/jekyll/template.rb
@@ -130,7 +130,7 @@ module Jekyll
         store = context.registers[:template_data_store]
         if store.keys.size
           if store.keys[0] == @id
-            store = {}
+            context.registers[:template_data_store] = false
           else
             context["template"] = store[store.keys[0]]
           end

--- a/test/source/_posts/2016-01-22-double-nested-yaml.md
+++ b/test/source/_posts/2016-01-22-double-nested-yaml.md
@@ -1,0 +1,13 @@
+{% template yaml-nest.html %}
+---
+puts: true
+title: "You"
+---
+{% endtemplate %}
+
+{% template yaml-nest.html %}
+---
+puts: true
+title: "WUT M8"
+---
+{% endtemplate %}

--- a/test/source/_templates/yaml-nest.html
+++ b/test/source/_templates/yaml-nest.html
@@ -1,6 +1,5 @@
 ---
 title: "Hello"
-should-be: "Hello"
 ---
 
 {% template data.html %}

--- a/test/test_template_yaml.rb
+++ b/test/test_template_yaml.rb
@@ -18,7 +18,7 @@ EXPECTED
       assert_equal(expected, post.output)
     end
 
-    should "WUT" do
+    should "render nested templates while preserving scope of YAML data" do
       post = @site.posts.docs[20]
       expected = <<EXPECTED
 <h1>Level 3</h1>
@@ -30,5 +30,22 @@ EXPECTED
       assert_equal(expected, post.output)
     end
 
+    should "render multiple nested templates while preserving scope of YAML data" do
+      post = @site.posts.docs[21]
+      expected = <<EXPECTED
+<h1>Level 3</h1>
+<h1>Default title</h1>
+<h1>Level 1</h1>
+<h1>Level 1 Dupe</h1>
+<h1>You</h1>
+
+<h1>Level 3</h1>
+<h1>Default title</h1>
+<h1>Level 1</h1>
+<h1>Level 1 Dupe</h1>
+<h1>WUT M8</h1>
+EXPECTED
+      assert_equal(expected, post.output)
+    end
   end
 end


### PR DESCRIPTION
Followup to https://github.com/helpscout/jekyll-template/pull/4